### PR TITLE
README: Add firewall instructions for UDP traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,11 @@ application uses a POD that will contain the application Docker container
 alongside with a monitor container that will gather data for the statistics.
 
 One POD will also be used to deploy a router that will simply run OpenVPN so
-that the simulation can open a tunnel to the cluster network and thus make
-requests to the nodes.
+that the simulation can open a tunnel to the cluster network, on the `simnet-router`
+pod and thus make requests to the simnet nodes. Simnet uses a NodePort to
+communicate with the Kubernetes node running the `simnet-router` Pod. If you
+are using a public cloud provider, please ensure the NodeIP is publically
+accessible and UDP traffic is allowed on the cluster.
 
 ### Docker
 


### PR DESCRIPTION
Katja ran into some issues while trying to setup the simulations on Azure and GKE. Turns out the default firewall blocks all incoming UDP traffic. As a result the deployments failed because we couldn't establish a VPN connection to the `simnet-router` Pod (the error indicated TLS key negotiation failure due to timeout).

This PR updates the README to remind the users that they need to ensure UDP traffic is allowed on their Kubernetes cluster.